### PR TITLE
fixed the condition for blog loading status

### DIFF
--- a/src/views/Blog/BlogPost/index.js
+++ b/src/views/Blog/BlogPost/index.js
@@ -17,11 +17,11 @@ class BlogPost extends Component {
     dispatch({ type: 'API:GET_BLOG', payload: { post }})
   }
   render() {
-    const { api, post } = this.props;
+    const { api, status, post } = this.props;
     const { blogs } = api || {};
     const { blog_id, src } = post;
     return (
-      <Loading on={blogs[blog_id]}>
+      <Loading on={status.loaded.includes(`GET_BLOG_${blog_id}`)}>
         <article className="BlogPost" dangerouslySetInnerHTML={{ __html: src }} />
       </Loading>
     );


### PR DESCRIPTION
- The `BlogPost` component was relying on a condition that wasn't definitive on the status for having been loaded.
- Changed this to rely on the `StatusReducer` directly.