### PR TITLE
50 GA Reporting Adjustment

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -25,8 +25,11 @@ function withAnalytics(WrappedComponent) {
       super(props);
     }
     componentDidMount() {
+      const is_development = (!process || !process.env || !process.env.NODE_ENV) || process.env.NODE_ENV === 'development';
       const { location } = this.props;
-      if (location) analytics.pageview(location.pathname);
+      if (is_development) {
+        console.info('ANALYTICS:VIEW', 'Development - Skipping Google Analytics page view.');
+      } else if (location) analytics.pageview(location.pathname);
     }
     render() {
       return <WrappedComponent {...this.props} />;


### PR DESCRIPTION
- Added a conditional in the automatic `pageview` call to prevent views on `localhost` from being reported.

This should at least reduce a few of the duplicates. Google Analytics runs off of a `Cookie` on the user's browser. This being said, the domain that they are visiting is reported as a new view even if it's on the same machine.

So having a tab open to `v3.dataskeptic.com` and another tab at `localhost:5001` causes two views to show up. Now, this adds a third view if you also have a tab open at `localhost:5000` as well, since they are considered separate domains.

This conditional should at least make our analytics a bit more reliable.

Resolves #50 